### PR TITLE
Fix pivot character

### DIFF
--- a/lib/src/main/java/pro/dbro/openspritz/Spritzer.java
+++ b/lib/src/main/java/pro/dbro/openspritz/Spritzer.java
@@ -137,7 +137,7 @@ public class Spritzer {
         if (word.length() > 7) {
             StringBuilder builder = new StringBuilder();
             int beginPad = (word.length() / 2) - 3;
-            for(int x = 0; x < beginPad; x++) {
+            for(int x = 0; x <= beginPad; x++) {
                 builder.append(" ");
             }
             builder.append(word);


### PR DESCRIPTION
The current implementation sets the max pivot to the 5th character not the 4th. This should fix that issue.
