### PR TITLE
Use JSoup for HTML parsing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile 'org.slf4j:slf4j-android:1.7.6'
     compile 'com.android.support:support-v4:+'
     compile 'com.squareup:otto:1.3.4'
+    compile 'org.jsoup:jsoup:1.7.3'
 
     compile project(":lib")
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -17,3 +17,7 @@
 #}
 
 -dontwarn javax.xml.**
+
+-keep public class org.jsoup.** {
+    public *;
+}

--- a/app/src/main/java/pro/dbro/openspritz/EpubSpritzer.java
+++ b/app/src/main/java/pro/dbro/openspritz/EpubSpritzer.java
@@ -72,7 +72,7 @@ public class EpubSpritzer extends Spritzer {
             }
             mEpubUri = epubUri;
             mBook = (new EpubReader()).readEpub(epubInputStream);
-            mMaxChapter = mBook.getSpine().getSpineReferences().size();
+            mMaxChapter = mBook.getTableOfContents().size();
             restoreState(false);
         } catch (IOException e) {
             e.printStackTrace();
@@ -119,7 +119,7 @@ public class EpubSpritzer extends Spritzer {
 
     private String loadCleanStringFromChapter(int chapter) {
         try {
-            String bookStr = new String(mBook.getSpine().getResource(chapter).getData(), "UTF-8");
+            String bookStr = new String(mBook.getTableOfContents().getTocReferences().get(chapter).getResource().getData(), "UTF-8");
             return Html.fromHtml(bookStr).toString().replace("\n", "").replaceAll("(?s)<!--.*?-->", "");
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/pro/dbro/openspritz/EpubSpritzer.java
+++ b/app/src/main/java/pro/dbro/openspritz/EpubSpritzer.java
@@ -10,6 +10,10 @@ import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.safety.Whitelist;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -117,10 +121,17 @@ public class EpubSpritzer extends Spritzer {
         if (VERBOSE) Log.i(TAG, "starting next chapter: " + mChapter);
     }
 
+    private static String extractText(String html) {
+        String filteredLineBreaks = Jsoup.clean(html, "", Whitelist.none().addTags("br", "p"), new Document.OutputSettings().prettyPrint(true));
+        return Jsoup.clean(filteredLineBreaks, "", Whitelist.none(), new Document.OutputSettings().prettyPrint(false));
+    }
+
     private String loadCleanStringFromChapter(int chapter) {
         try {
-            String bookStr = new String(mBook.getTableOfContents().getTocReferences().get(chapter).getResource().getData(), "UTF-8");
-            return Html.fromHtml(bookStr).toString().replace("\n", "").replaceAll("(?s)<!--.*?-->", "");
+            byte[] bookData = mBook.getTableOfContents().getTocReferences().get(chapter).getResource().getData();
+            String bookStr = new String(bookData, "UTF-8");
+
+            return extractText(bookStr);
         } catch (IOException e) {
             e.printStackTrace();
             Log.e(TAG, "Parsing failed " + e.getMessage());

--- a/app/src/main/java/pro/dbro/openspritz/EpubSpritzer.java
+++ b/app/src/main/java/pro/dbro/openspritz/EpubSpritzer.java
@@ -72,7 +72,7 @@ public class EpubSpritzer extends Spritzer {
             }
             mEpubUri = epubUri;
             mBook = (new EpubReader()).readEpub(epubInputStream);
-            mMaxChapter = mBook.getTableOfContents().size();
+            mMaxChapter = mBook.getTableOfContents().getTocReferences().size();
             restoreState(false);
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/pro/dbro/openspritz/MainActivity.java
+++ b/app/src/main/java/pro/dbro/openspritz/MainActivity.java
@@ -7,13 +7,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 import android.view.Window;
 
 import nl.siegmann.epublib.domain.Book;

--- a/app/src/main/java/pro/dbro/openspritz/MainActivity.java
+++ b/app/src/main/java/pro/dbro/openspritz/MainActivity.java
@@ -16,7 +16,7 @@ import android.view.Window;
 
 import nl.siegmann.epublib.domain.Book;
 
-public class MainActivity extends ActionBarActivity implements WpmDialogFragment.OnWpmSelectListener, ChapterListDialogFragment.OnChapterSelectListener, SpritzFragment.SpritzFragmentListener {
+public class MainActivity extends ActionBarActivity implements WpmDialogFragment.OnWpmSelectListener, TocDialogFragment.OnChapterSelectListener, SpritzFragment.SpritzFragmentListener {
     private static final String TAG = "MainActivity";
     private static final String PREFS = "ui_prefs";
     private static final int THEME_LIGHT = 0;
@@ -141,7 +141,7 @@ public class MainActivity extends ActionBarActivity implements WpmDialogFragment
         if (frag.getSpritzer() != null) {
             Book book = frag.getSpritzer().getBook();
             FragmentTransaction ft = getFragmentManager().beginTransaction();
-            DialogFragment newFragment = ChapterListDialogFragment.newInstance(book);
+            DialogFragment newFragment = TocDialogFragment.newInstance(book);
             newFragment.show(ft, "dialog");
         } else {
             Log.e(TAG, "SpritzFragment not available for chapter selection");

--- a/app/src/main/java/pro/dbro/openspritz/SpineReferenceAdapter.java
+++ b/app/src/main/java/pro/dbro/openspritz/SpineReferenceAdapter.java
@@ -17,7 +17,7 @@ import nl.siegmann.epublib.domain.SpineReference;
 public class SpineReferenceAdapter extends ArrayAdapter<SpineReference> {
 
     public SpineReferenceAdapter(final Context context, int resource, List<SpineReference> objects) {
-        super(context, R.layout.chapter_list_item, objects);
+        super(context, resource, objects);
     }
 
     public View getView(int position, View convertView, ViewGroup parent) {

--- a/app/src/main/java/pro/dbro/openspritz/SpritzFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/SpritzFragment.java
@@ -84,10 +84,10 @@ public class SpritzFragment extends Fragment {
         int curChapter = mSpritzer.getCurrentChapter();
         mTitleView.setText(meta.getFirstTitle());
         String chapterText;
-        if (book.getSpine().getResource(curChapter).getTitle() == null || book.getSpine().getResource(curChapter).getTitle().trim().compareTo("") == 0) {
+        if (book.getTableOfContents().getTocReferences().get(curChapter).getResource().getTitle() == null || book.getTableOfContents().getTocReferences().get(curChapter).getResource().getTitle().compareTo("") == 0) {
             chapterText = String.format("Chapter %d", curChapter);
         } else {
-            chapterText = book.getSpine().getResource(curChapter).getTitle();
+            chapterText = book.getTableOfContents().getTocReferences().get(curChapter).getResource().getTitle();
         }
 
         int startSpan = chapterText.length();

--- a/app/src/main/java/pro/dbro/openspritz/SpritzFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/SpritzFragment.java
@@ -50,11 +50,6 @@ public class SpritzFragment extends Fragment {
         // Required empty public constructor
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
     public void feedEpubToSpritzer(Uri epubPath) {
         if (mSpritzer == null) {
             mSpritzer = new EpubSpritzer(mSpritzView, epubPath);
@@ -241,11 +236,6 @@ public class SpritzFragment extends Fragment {
         if (mBus != null) {
             mBus.unregister(this);
         }
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
     }
 
     @Subscribe

--- a/app/src/main/java/pro/dbro/openspritz/TocDialogFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/TocDialogFragment.java
@@ -14,15 +14,15 @@ import nl.siegmann.epublib.domain.Book;
 /**
  * Created by davidbrodsky on 3/1/14.
  */
-public class ChapterListDialogFragment extends DialogFragment implements ListView.OnItemClickListener {
+public class TocDialogFragment extends DialogFragment implements ListView.OnItemClickListener {
 
     private Book mBook;
-    private SpineReferenceAdapter mAdapter;
+    private TocReferenceAdapter mAdapter;
     private ListView mList;
     private OnChapterSelectListener mOnChapterSelectListener;
 
-    static ChapterListDialogFragment newInstance(Book book) {
-        ChapterListDialogFragment f = new ChapterListDialogFragment();
+    static TocDialogFragment newInstance(Book book) {
+        TocDialogFragment f = new TocDialogFragment();
 
         Bundle args = new Bundle();
         args.putSerializable("book", book);
@@ -46,7 +46,7 @@ public class ChapterListDialogFragment extends DialogFragment implements ListVie
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mBook = (Book) getArguments().getSerializable("book");
-        mAdapter = new SpineReferenceAdapter(getActivity(), R.layout.chapter_list_item, mBook.getSpine().getSpineReferences());
+        mAdapter = new TocReferenceAdapter(getActivity(), R.layout.chapter_list_item, mBook.getTableOfContents());
     }
 
     @Override

--- a/app/src/main/java/pro/dbro/openspritz/TocReferenceAdapter.java
+++ b/app/src/main/java/pro/dbro/openspritz/TocReferenceAdapter.java
@@ -30,7 +30,7 @@ public class TocReferenceAdapter extends ArrayAdapter<TOCReference> {
         if (ref.getTitle() == null || ref.getTitle().trim().compareTo("") == 0) {
             ((TextView) convertView.findViewById(R.id.title)).setText(String.format("Chapter %d", position));
         } else {
-            ((TextView) convertView.findViewById(R.id.title)).setText(ref.getTitle());
+            ((TextView) convertView.findViewById(R.id.title)).setText(String.format("%d: %s", position, ref.getTitle()));
         }
         return convertView;
     }

--- a/app/src/main/java/pro/dbro/openspritz/TocReferenceAdapter.java
+++ b/app/src/main/java/pro/dbro/openspritz/TocReferenceAdapter.java
@@ -7,17 +7,16 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-import java.util.List;
-
-import nl.siegmann.epublib.domain.SpineReference;
+import nl.siegmann.epublib.domain.TOCReference;
+import nl.siegmann.epublib.domain.TableOfContents;
 
 /**
  * Created by davidbrodsky on 3/5/14.
  */
-public class SpineReferenceAdapter extends ArrayAdapter<SpineReference> {
+public class TocReferenceAdapter extends ArrayAdapter<TOCReference> {
 
-    public SpineReferenceAdapter(final Context context, int resource, List<SpineReference> objects) {
-        super(context, resource, objects);
+    public TocReferenceAdapter(final Context context, int resource, TableOfContents toc) {
+        super(context, resource, toc.getTocReferences());
     }
 
     public View getView(int position, View convertView, ViewGroup parent) {
@@ -27,11 +26,11 @@ public class SpineReferenceAdapter extends ArrayAdapter<SpineReference> {
             assert convertView != null;
 
         }
-        SpineReference ref = getItem(position);
-        if (ref.getResource().getTitle() == null || ref.getResource().getTitle().trim().compareTo("") == 0) {
+        TOCReference ref = getItem(position);
+        if (ref.getTitle() == null || ref.getTitle().trim().compareTo("") == 0) {
             ((TextView) convertView.findViewById(R.id.title)).setText(String.format("Chapter %d", position));
         } else {
-            ((TextView) convertView.findViewById(R.id.title)).setText(ref.getResource().getTitle());
+            ((TextView) convertView.findViewById(R.id.title)).setText(ref.getTitle());
         }
         return convertView;
     }

--- a/app/src/main/java/pro/dbro/openspritz/WpmDialogFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/WpmDialogFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.View;
 import android.view.animation.Animation;

--- a/app/src/main/java/pro/dbro/openspritz/events/NextChapterEvent.java
+++ b/app/src/main/java/pro/dbro/openspritz/events/NextChapterEvent.java
@@ -5,7 +5,7 @@ package pro.dbro.openspritz.events;
  */
 public class NextChapterEvent {
 
-    private int mChapter;
+    private final int mChapter;
 
     public NextChapterEvent(int chapter){
         mChapter = chapter;


### PR DESCRIPTION
HTML parsing is very error prone. OpenSpritz is using Android's HTML and then applying a regex. This has multiple problems:
- CSS is not properly parsed
- There is no guarantee that the regex properly filters HTML.

Enter JSoup, it understands the tree and can make more informed decisions. Additionally it has a clean method which is exactly what we want.

When proguarded this adds ~80kb to the final APK.
