### PR TITLE
Replace fragment listeners by otto events.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Light" >
+        android:theme="@style/Light"
+        android:name=".OpenSpritzApplication"
+        >
         <activity
             android:name=".MainActivity" >
             <intent-filter>

--- a/app/src/main/java/pro/dbro/openspritz/ChapterListDialogFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/ChapterListDialogFragment.java
@@ -9,7 +9,10 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
+import com.squareup.otto.Bus;
+
 import nl.siegmann.epublib.domain.Book;
+import pro.dbro.openspritz.events.ChapterSelectedEvent;
 
 /**
  * Created by davidbrodsky on 3/1/14.
@@ -19,7 +22,7 @@ public class ChapterListDialogFragment extends DialogFragment implements ListVie
     private Book mBook;
     private SpineReferenceAdapter mAdapter;
     private ListView mList;
-    private OnChapterSelectListener mOnChapterSelectListener;
+    private Bus mBus;
 
     static ChapterListDialogFragment newInstance(Book book) {
         ChapterListDialogFragment f = new ChapterListDialogFragment();
@@ -29,17 +32,6 @@ public class ChapterListDialogFragment extends DialogFragment implements ListVie
         f.setArguments(args);
 
         return f;
-    }
-
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        try {
-            mOnChapterSelectListener = (OnChapterSelectListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString()
-                    + " must implement SpritzFragmentListener");
-        }
     }
 
     @Override
@@ -57,6 +49,9 @@ public class ChapterListDialogFragment extends DialogFragment implements ListVie
         mList.setAdapter(mAdapter);
         mList.setOnItemClickListener(this);
 
+        OpenSpritzApplication app = (OpenSpritzApplication) getActivity().getApplication();
+        this.mBus = ((OpenSpritzApplication)getActivity().getApplication()).getBus();
+
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(getActivity().getString(R.string.select_chapter))
                 .setView(v);
@@ -65,11 +60,7 @@ public class ChapterListDialogFragment extends DialogFragment implements ListVie
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        mOnChapterSelectListener.onChapterSelected(position);
+        mBus.post(new ChapterSelectedEvent(position));
         getDialog().dismiss();
-    }
-
-    public interface OnChapterSelectListener {
-        public abstract void onChapterSelected(int chapter);
     }
 }

--- a/app/src/main/java/pro/dbro/openspritz/OpenSpritzApplication.java
+++ b/app/src/main/java/pro/dbro/openspritz/OpenSpritzApplication.java
@@ -1,0 +1,30 @@
+package pro.dbro.openspritz;
+
+import android.app.Application;
+
+import com.squareup.otto.Bus;
+import com.squareup.otto.ThreadEnforcer;
+
+/**
+ * A custom application that sets up common functionality.
+ *
+ * @author defer (diogo@underdev.org)
+ */
+public class OpenSpritzApplication extends Application {
+    private Bus mBus;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        this.mBus = new Bus(ThreadEnforcer.ANY);
+    }
+
+    /**
+     * Obtains the Bus that is used throughout the App.
+     *
+     * @return The bus instance used throughout the app.
+     */
+    public Bus getBus() {
+        return this.mBus;
+    }
+}

--- a/app/src/main/java/pro/dbro/openspritz/SpritzFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/SpritzFragment.java
@@ -1,6 +1,5 @@
 package pro.dbro.openspritz;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
@@ -18,13 +17,13 @@ import android.widget.TextView;
 
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
 
 import java.util.List;
 
 import nl.siegmann.epublib.domain.Author;
 import nl.siegmann.epublib.domain.Book;
 import nl.siegmann.epublib.domain.Metadata;
+import pro.dbro.openspritz.events.ChapterSelectRequested;
 import pro.dbro.openspritz.events.NextChapterEvent;
 import pro.dbro.openspritz.events.SpritzFinishedEvent;
 
@@ -38,8 +37,6 @@ public class SpritzFragment extends Fragment {
     private ProgressBar mProgress;
     private TextView mSpritzView;
     private Bus mBus;
-
-    private SpritzFragmentListener mSpritzFragmentListener;
 
     public static SpritzFragment newInstance() {
         SpritzFragment fragment = new SpritzFragment();
@@ -166,7 +163,7 @@ public class SpritzFragment extends Fragment {
         mChapterView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mSpritzFragmentListener.onChapterSelectRequested();
+                mBus.post(new ChapterSelectRequested());
             }
         });
         mProgress = ((ProgressBar) root.findViewById(R.id.progress));
@@ -192,20 +189,10 @@ public class SpritzFragment extends Fragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        try {
-            mSpritzFragmentListener = (SpritzFragmentListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString()
-                    + " must implement SpritzFragmentListener");
-        }
-    }
-
-    @Override
     public void onStart() {
         super.onStart();
-        mBus = new Bus(ThreadEnforcer.ANY);
+        OpenSpritzApplication app = (OpenSpritzApplication) getActivity().getApplication();
+        mBus = app.getBus();
         mBus.register(this);
         if (mSpritzer == null) {
             mSpritzer = new EpubSpritzer(mSpritzView);
@@ -313,9 +300,4 @@ public class SpritzFragment extends Fragment {
             updateMetaUi();
         }
     }
-
-    public interface SpritzFragmentListener {
-        public abstract void onChapterSelectRequested();
-    }
-
 }

--- a/app/src/main/java/pro/dbro/openspritz/WpmDialogFragment.java
+++ b/app/src/main/java/pro/dbro/openspritz/WpmDialogFragment.java
@@ -12,6 +12,10 @@ import android.view.animation.AnimationUtils;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import com.squareup.otto.Bus;
+
+import pro.dbro.openspritz.events.WpmSelectedEvent;
+
 /**
  * Created by davidbrodsky on 3/1/14.
  */
@@ -26,8 +30,8 @@ public class WpmDialogFragment extends DialogFragment {
     private boolean mAnimationRunning;
     private SeekBar mWpmSeek;
     private TextView mWpmLabel;
-    private OnWpmSelectListener mOnWpmSelectListener;
     private int mWpm;
+    private Bus mBus;
 
     static WpmDialogFragment newInstance(int wpm) {
         WpmDialogFragment f = new WpmDialogFragment();
@@ -41,21 +45,13 @@ public class WpmDialogFragment extends DialogFragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        try {
-            mOnWpmSelectListener = (OnWpmSelectListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString()
-                    + " must implement OnWpmSelectListener");
-        }
-    }
-
-    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mWpm = Math.max(MIN_WPM, getArguments().getInt("wpm"));
         mAnimationRunning = false;
+
+        OpenSpritzApplication app = (OpenSpritzApplication) getActivity().getApplication();
+        this.mBus = app.getBus();
     }
 
     @Override
@@ -74,7 +70,7 @@ public class WpmDialogFragment extends DialogFragment {
                 mWpm = Math.max(MIN_WPM, (int) ((progress / 100.0) * MAX_WPM));
                 String wpmStr = mWpm + " WPM";
                 mWpmLabel.setText(wpmStr);
-                mOnWpmSelectListener.onWpmSelected(mWpm);
+                mBus.post(new WpmSelectedEvent(mWpm));
                 getDialog().setTitle(wpmStr);
                 if (mWpm >= WHOAH_THRESHOLD_WPM + 50 && !mAnimationRunning) {
                     setTrippin(true);
@@ -114,9 +110,5 @@ public class WpmDialogFragment extends DialogFragment {
             mView.clearAnimation();
             mAnimationRunning = false;
         }
-    }
-
-    public interface OnWpmSelectListener {
-        public abstract void onWpmSelected(int wpm);
     }
 }

--- a/app/src/main/java/pro/dbro/openspritz/events/ChapterSelectRequested.java
+++ b/app/src/main/java/pro/dbro/openspritz/events/ChapterSelectRequested.java
@@ -1,0 +1,7 @@
+package pro.dbro.openspritz.events;
+
+/**
+ * Event that is fired whenever the user requests to select a chapter.
+ */
+public class ChapterSelectRequested {
+}

--- a/app/src/main/java/pro/dbro/openspritz/events/ChapterSelectedEvent.java
+++ b/app/src/main/java/pro/dbro/openspritz/events/ChapterSelectedEvent.java
@@ -1,0 +1,18 @@
+package pro.dbro.openspritz.events;
+
+/**
+ * Event that is fired whenever a chapter is selected.
+ *
+ * @author defer (diogo@underdev.org)
+ */
+public class ChapterSelectedEvent {
+    private final int mChapter;
+
+    public ChapterSelectedEvent(int chapter) {
+        this.mChapter = chapter;
+    }
+
+    public int getChapter() {
+        return this.mChapter;
+    }
+}

--- a/app/src/main/java/pro/dbro/openspritz/events/WpmSelectedEvent.java
+++ b/app/src/main/java/pro/dbro/openspritz/events/WpmSelectedEvent.java
@@ -1,0 +1,17 @@
+package pro.dbro.openspritz.events;
+
+/**
+ * Event that is fired whenever the user requests to change
+ * the WPM rate.
+ */
+public class WpmSelectedEvent {
+    private final int mWpm;
+
+    public WpmSelectedEvent(int wpm) {
+        this.mWpm = wpm;
+    }
+
+    public int getWpm() {
+        return this.mWpm;
+    }
+}


### PR DESCRIPTION
Listeners are fine, but since we use Otto already we might as well
leverage it and remove the listeners. Listeners are always troublesome
because they are hard to handle (i.e. most listeners won't unregister
themselves leaving references to potentially inconsistent resources) and
writing good listener management is not trivial. The event bus solves
this for us.

Since Otto is now used everywhere, I also added a OpenSpritzApplication
that contains Otto and might contain other global stuff in the future.
