### PR TITLE
Newlines between words in EPUBS were causing words

### DIFF
--- a/app/src/main/java/pro/dbro/openspritz/formats/Epub.java
+++ b/app/src/main/java/pro/dbro/openspritz/formats/Epub.java
@@ -133,7 +133,7 @@ public class Epub implements SpritzerMedia {
             if (bookStr.contains("<body")) {
                 bookStr = bookStr.substring(bookStr.indexOf("<body"));
             }
-            return Html.fromHtml(bookStr).toString().replace("\n", "").replaceAll("(?s)<!--.*?-->", "");
+            return Html.fromHtml(bookStr).toString().replaceAll("\\n+", " ").replaceAll("(?s)<!--.*?-->", "");
         } catch (IOException e) {
             e.printStackTrace();
             Log.e(TAG, "Parsing failed " + e.getMessage());


### PR DESCRIPTION
to be concatenated. 

The last word of the line, its punctuation and the first word of the next line were being concatenated because of .replace(\n, '') on line 136 of Epub.java. For example, if this commit message were being Spritzed, 'concatenated.' and 'The' would be concatenated. 

Html.fromHtml(bookStr).toString().replaceAll("\n+", " ") would replace all newlines between 'concatenated.' and 'The' with a single space. 
